### PR TITLE
fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ cache: packages
 latex: false
 
 apt_packages:
-  - libgsl-dev
-  
-brew_packages: 
+  - libgsl0-dev
+
+brew_packages:
   - gsl
- 
+
 jobs:
   include:
   - r: devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@
 
 language: R
 sudo: required
-dist: trusty
+dist: bionic
 cache: packages
 latex: false
 
 apt_packages:
-  - libgsl0-dev
+  - libgsl-dev
 
 brew_packages:
   - gsl


### PR DESCRIPTION
`libgsl-dev` can't be installed on Ubuntu trusty and `libgsl0-dev` is insufficient for the current `gsl` R package. It seems to work with Ubuntu bionic.