### PR TITLE
Make minimal references to some packages that R-CMD-CHECK does not see

### DIFF
--- a/R/imports.R
+++ b/R/imports.R
@@ -1,7 +1,0 @@
-# These imports are made to pass a CRAN note. The imports are not redundant,
-# but are used only through eval-call in the code, which is invisible to the
-# CRAN checks.
-
-invisible(extraDistr::dbetapr)
-invisible(logitnorm::dlogitnorm)
-invisible(tibble::tibble)

--- a/R/mlbetapr.R
+++ b/R/mlbetapr.R
@@ -34,6 +34,9 @@ mlbetapr <- function(x, na.rm = FALSE, ...) {
   ml_input_checker(x)
   assertthat::assert_that(min(x) > 0)
 
+  # Make a minimal reference to extraDistr package so that R-CMD-CHECK recognizes it
+  invisible(extraDistr::dbetapr)
+
   val1 <- mean(log(x))
   val2 <- mean(log(1 + x))
   object <- mlbeta(x / (x + 1), na.rm = FALSE, ...)

--- a/R/mllogitnorm.R
+++ b/R/mllogitnorm.R
@@ -34,6 +34,9 @@ mllogitnorm <- function(x, na.rm = FALSE, ...) {
   assertthat::assert_that(min(x) > 0)
   assertthat::assert_that(max(x) < 1)
 
+  # Make a minimal reference to logitnorm package so that R-CMD-CHECK recognizes it
+  invisible(logitnorm::dlogitnorm)
+
   n <- length(x)
   y <- stats::qlogis(x)
   mu <- mean(y)

--- a/R/mlnaka.R
+++ b/R/mlnaka.R
@@ -37,6 +37,10 @@ mlnaka <- function(x, na.rm = FALSE, ...) {
   if (na.rm) x <- x[!is.na(x)] else assertthat::assert_that(!anyNA(x))
   ml_input_checker(x)
   assertthat::assert_that(min(x) > 0)
+
+  # Make a minimal reference to nakagami package so that R-CMD-CHECK recognizes it
+  invisible(nakagami::dnaka)
+
   n <- length(x)
 
   object <- mlgamma(x^2, na.rm = na.rm, ...)


### PR DESCRIPTION
When trying to CHECK the package for another PR, I keep running into the annoying point that `R-CMD-CHECK` does not see some usages of some packages and so keeps on complaining about it. I saw your attempt to get around this with the `imports.R` file, but unfortunately, that doesn't seem to work. So, I've tried to fix this by adding the `invisible()` calls directly in some relevant `ml*` functions. That's a bit messy since it clutters the code just for a workaround, but it should permanently silence `R-CMD-CHECK`. So, this PR is just a proposal; I don't know if you'll like this workaround.

Note that I did not do anything about the `tibble` reference because I've submitted another PR (https://github.com/JonasMoss/univariateML/pull/53) that directly uses the `tibble` package, thus resolving the issue legitimately.